### PR TITLE
build!: upgrade engines field to >=8.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.10.0"
   }
 }


### PR DESCRIPTION
This drops support for all Node.js versions < 8.10.0, please upgrade

BREAKING CHANGE: library now requires Node >= 8.10.0