### PR TITLE
test: there's a race condition consuming from queue

### DIFF
--- a/samples/test/containerAnalysis.test.js
+++ b/samples/test/containerAnalysis.test.js
@@ -343,8 +343,8 @@ describe('pubsub', () => {
     await pubsub.subscription(subscriptionId).delete();
   });
 
-  it('should get accurate count of occurrences from pubsub topic', async () => {
-    const expectedNum = 3;
+  it('should get count of occurrences from pubsub topic', async () => {
+    const occurrenceCount = 3;
     const pubSubOccurrenceReq = {
       parent: formattedParent,
       occurrence: {
@@ -372,14 +372,8 @@ describe('pubsub', () => {
       `node occurrencePubSub.js "${projectId}" "${subscriptionId}" "${timeoutSeconds}"`
     );
 
-    // make sure empty
-    const empty = execSync(
-      `node occurrencePubSub.js "${projectId}" "${subscriptionId}" "${timeoutSeconds}"`
-    );
-
-    assert.include(empty, 'Polled 0 occurrences');
     // create test occurrences
-    for (let i = 0; i < expectedNum; i++) {
+    for (let i = 0; i < occurrenceCount; i++) {
       const [
         pubSubOccurrence,
       ] = await client.getGrafeasClient().createOccurrence(pubSubOccurrenceReq);
@@ -391,7 +385,7 @@ describe('pubsub', () => {
       `node occurrencePubSub.js "${projectId}" "${subscriptionId}" "${timeoutSeconds}"`
     );
 
-    // make sure pubsub number matches
-    assert.include(output, `Polled ${expectedNum} occurrences`);
+    // ensure that our occcurences were enqueued:
+    assert.match(output, /Polled [1-9]+ occurrences/);
   });
 });


### PR DESCRIPTION
There's an occasional race condition between emptying the pub-sub queue and checking the number of entries in the queue, as evidenced by someone having added an extra call to the empty subscription check in the past.

Let's just make sure that at least some jobs were enqueued, rather than trying to pin the exact number.