### PR TITLE
fix: remove unneeded common protos in generated proto list

### DIFF
--- a/src/v1beta1/grafeas_v1_beta1_client.ts
+++ b/src/v1beta1/grafeas_v1_beta1_client.ts
@@ -541,7 +541,7 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.parent
    *   The name of the project in the form of `projects/[PROJECT_ID]`, under which
    *   the occurrence is to be created.
-   * @param {grafeas.v1beta1.Occurrence} request.occurrence
+   * @param {grafeas.v1.Occurrence} request.occurrence
    *   The occurrence to create.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -625,7 +625,7 @@ export class GrafeasV1Beta1Client {
    *   The name of the project in the form of `projects/[PROJECT_ID]`, under which
    *   the occurrences are to be created.
    * @param {number[]} request.occurrences
-   *   The occurrences to create.
+   *   The occurrences to create. Max allowed length is 1000.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -713,7 +713,7 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.name
    *   The name of the occurrence in the form of
    *   `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-   * @param {grafeas.v1beta1.Occurrence} request.occurrence
+   * @param {grafeas.v1.Occurrence} request.occurrence
    *   The updated occurrence.
    * @param {google.protobuf.FieldMask} request.updateMask
    *   The fields to update.
@@ -1044,7 +1044,7 @@ export class GrafeasV1Beta1Client {
    *   the note is to be created.
    * @param {string} request.noteId
    *   The ID to use for this note.
-   * @param {grafeas.v1beta1.Note} request.note
+   * @param {grafeas.v1.Note} request.note
    *   The note to create.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1128,7 +1128,7 @@ export class GrafeasV1Beta1Client {
    *   The name of the project in the form of `projects/[PROJECT_ID]`, under which
    *   the notes are to be created.
    * @param {number[]} request.notes
-   *   The notes to create.
+   *   The notes to create. Max allowed length is 1000.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -1210,7 +1210,7 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.name
    *   The name of the note in the form of
    *   `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-   * @param {grafeas.v1beta1.Note} request.note
+   * @param {grafeas.v1.Note} request.note
    *   The updated note.
    * @param {google.protobuf.FieldMask} request.updateMask
    *   The fields to update.
@@ -1400,7 +1400,8 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.filter
    *   The filter expression.
    * @param {number} request.pageSize
-   *   Number of occurrences to return in the list.
+   *   Number of occurrences to return in the list. Must be positive. Max allowed
+   *   page size is 1000. If not specified, page size defaults to 20.
    * @param {string} request.pageToken
    *   Token to provide to skip to a particular spot in the list.
    * @param {object} [options]
@@ -1483,7 +1484,8 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.filter
    *   The filter expression.
    * @param {number} request.pageSize
-   *   Number of occurrences to return in the list.
+   *   Number of occurrences to return in the list. Must be positive. Max allowed
+   *   page size is 1000. If not specified, page size defaults to 20.
    * @param {string} request.pageToken
    *   Token to provide to skip to a particular spot in the list.
    * @param {object} [options]
@@ -1526,7 +1528,8 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.filter
    *   The filter expression.
    * @param {number} request.pageSize
-   *   Number of occurrences to return in the list.
+   *   Number of occurrences to return in the list. Must be positive. Max allowed
+   *   page size is 1000. If not specified, page size defaults to 20.
    * @param {string} request.pageToken
    *   Token to provide to skip to a particular spot in the list.
    * @param {object} [options]
@@ -1594,7 +1597,8 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.filter
    *   The filter expression.
    * @param {number} request.pageSize
-   *   Number of notes to return in the list.
+   *   Number of notes to return in the list. Must be positive. Max allowed page
+   *   size is 1000. If not specified, page size defaults to 20.
    * @param {string} request.pageToken
    *   Token to provide to skip to a particular spot in the list.
    * @param {object} [options]
@@ -1677,7 +1681,8 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.filter
    *   The filter expression.
    * @param {number} request.pageSize
-   *   Number of notes to return in the list.
+   *   Number of notes to return in the list. Must be positive. Max allowed page
+   *   size is 1000. If not specified, page size defaults to 20.
    * @param {string} request.pageToken
    *   Token to provide to skip to a particular spot in the list.
    * @param {object} [options]
@@ -1720,7 +1725,8 @@ export class GrafeasV1Beta1Client {
    * @param {string} request.filter
    *   The filter expression.
    * @param {number} request.pageSize
-   *   Number of notes to return in the list.
+   *   Number of notes to return in the list. Must be positive. Max allowed page
+   *   size is 1000. If not specified, page size defaults to 20.
    * @param {string} request.pageToken
    *   Token to provide to skip to a particular spot in the list.
    * @param {object} [options]

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-containeranalysis.git",
-        "sha": "ba7ed36f683a1124d3bdf80c16095408e11ab2cc"
+        "remote": "git@github.com:googleapis/nodejs-containeranalysis.git",
+        "sha": "33cc13441237f0262ec6a8974a1beda1022cef90"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
-        "internalRef": "307114445"
+        "sha": "1b5a8d2bbb69c5a04db26bd546d2888e609c6bab",
+        "internalRef": "309845930"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -80,15 +80,15 @@ to_remove=['src/v1/grafeas_client.ts', 'src/v1/grafeas_client_config.json', 'src
 for filePath in to_remove:
     os.unlink(filePath)
 # remove unneeded protos in proto_list.json
-proto_lists=['src/v1/container_analysis_proto_list.json', 'src/v1beta1/container_analysis_v1_beta1_proto_list.json', 'src/v1beta1/grafeas_v1_beta1_proto_list.json']
-remove_proto_keywords=['/google/api', '/google/protobuf', '/google/rpc', '/google/type']
-for file in proto_lists:
-  with open(file, 'r') as f:
-    items=json.load(f)
-    content =[item for item in items if all([(x not in item) for x in remove_proto_keywords])]
-    new_file=json.dumps(content, indent=2) + '\n'
-  with open(file, 'w') as f:
-    f.write(new_file)
+# proto_lists=['src/v1/container_analysis_proto_list.json', 'src/v1beta1/container_analysis_v1_beta1_proto_list.json', 'src/v1beta1/grafeas_v1_beta1_proto_list.json']
+# remove_proto_keywords=['/google/api', '/google/protobuf', '/google/rpc', '/google/type']
+# for file in proto_lists:
+#   with open(file, 'r') as f:
+#     items=json.load(f)
+#     content =[item for item in items if all([(x not in item) for x in remove_proto_keywords])]
+#     new_file=json.dumps(content, indent=2) + '\n'
+#   with open(file, 'w') as f:
+#     f.write(new_file)
 
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])

--- a/test/gapic_container_analysis_v1.ts
+++ b/test/gapic_container_analysis_v1.ts
@@ -236,9 +236,7 @@ describe('v1.ContainerAnalysisClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -350,9 +348,7 @@ describe('v1.ContainerAnalysisClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -466,9 +462,7 @@ describe('v1.ContainerAnalysisClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)

--- a/test/gapic_container_analysis_v1_beta1_v1beta1.ts
+++ b/test/gapic_container_analysis_v1_beta1_v1beta1.ts
@@ -319,9 +319,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.setIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.setIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.setIamPolicy as SinonStub)
           .getCall(0)
@@ -439,9 +437,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getIamPolicy(request);
-      }, expectedError);
+      await assert.rejects(client.getIamPolicy(request), expectedError);
       assert(
         (client.innerApiCalls.getIamPolicy as SinonStub)
           .getCall(0)
@@ -561,9 +557,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.testIamPermissions(request);
-      }, expectedError);
+      await assert.rejects(client.testIamPermissions(request), expectedError);
       assert(
         (client.innerApiCalls.testIamPermissions as SinonStub)
           .getCall(0)
@@ -681,9 +675,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.getScanConfig(request);
-      }, expectedError);
+      await assert.rejects(client.getScanConfig(request), expectedError);
       assert(
         (client.innerApiCalls.getScanConfig as SinonStub)
           .getCall(0)
@@ -801,9 +793,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.updateScanConfig(request);
-      }, expectedError);
+      await assert.rejects(client.updateScanConfig(request), expectedError);
       assert(
         (client.innerApiCalls.updateScanConfig as SinonStub)
           .getCall(0)
@@ -939,9 +929,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.listScanConfigs(request);
-      }, expectedError);
+      await assert.rejects(client.listScanConfigs(request), expectedError);
       assert(
         (client.innerApiCalls.listScanConfigs as SinonStub)
           .getCall(0)
@@ -1046,9 +1034,7 @@ describe('v1beta1.ContainerAnalysisV1Beta1Client', () => {
           reject(err);
         });
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.descriptors.page.listScanConfigs.createStream as SinonStub)
           .getCall(0)


### PR DESCRIPTION
Rerun synthtool to pick up changes:

clean up synth.py, removing unneeded common protos in the generated list.
- related issue: googleapis/gapic-generator-typescript#455

fix comments
